### PR TITLE
Fix React root initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import AfDDoomsdayClock from "./AfDDoomsdayClock";
 import "./index.css";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <React.StrictMode>
     <AfDDoomsdayClock />
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- update the entry point to use `react-dom/client`'s `createRoot`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b30bbd8832782cf5b7516d97421